### PR TITLE
Upgrade to hapi v17

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Boom = require('boom');
-const Insync = require('insync');
 const Joi = require('joi');
 
 const schema = Joi.object({
@@ -15,16 +13,16 @@ const schema = Joi.object({
 });
 
 
-module.exports.register = function (server, options, next) {
+const register = function (server, options) {
   server.auth.scheme('nuisance', function nuisanceScheme (server, options) {
     Joi.assert(options, schema);
 
     return {
-      authenticate (request, reply) {
+      authenticate: async function (request, h) {
         const credentials = {};
         let scope = [];
 
-        Insync.eachSeries(options.strategies, function eachIterator (strategy, next) {
+        for (let strategy of options.strategies) {
           let failureCredentials = null;
 
           if (typeof strategy === 'object') {
@@ -32,42 +30,31 @@ module.exports.register = function (server, options, next) {
             strategy = strategy.name;
           }
 
-          server.auth.test(strategy, request, function testCb (err, creds) {
-            if (err) {
-              if (failureCredentials) {
-                creds = failureCredentials(request);
-              } else {
-                return next(err);
-              }
+          let creds = null;
+          try {
+            creds = await server.auth.test(strategy, request);
+          } catch (err) {
+            if (failureCredentials) {
+              creds = failureCredentials(request);
+            } else {
+              return h.unauthenticated(err);
             }
-
-            credentials[strategy] = creds;
-
-            if (creds !== null && typeof creds === 'object' && creds.scope) {
-              scope = scope.concat(creds.scope);
-            }
-
-            next();
-          });
-        }, function eachCb (err) {
-          if (err) {
-            return reply(Boom.unauthorized());
           }
-
-          if (scope.length !== 0) {
-            credentials.scope = scope;
+          credentials[strategy] = creds;
+          if (creds !== null && typeof creds === 'object' && creds.scope) {
+            scope = scope.concat(creds.scope);
           }
-
-          reply.continue({ credentials });
-        });
+        }
+        if (scope.length !== 0) {
+          credentials.scope = scope;
+        }
+        return h.authenticated({ credentials });
       }
     };
   });
-
-  next();
 };
 
-
-module.exports.register.attributes = {
+module.exports.plugin = {
+  register,
   pkg: require('../package.json')
 };

--- a/package.json
+++ b/package.json
@@ -21,15 +21,14 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "boom": "3.2.2",
-    "insync": "2.1.1",
     "joi": "9.0.4"
   },
   "devDependencies": {
-    "belly-button": "3.x.x",
+    "belly-button": "4.x.x",
+    "boom": "3.2.2",
     "code": "3.x.x",
-    "hapi": "14.x.x",
-    "lab": "10.x.x"
+    "hapi": "17.x.x",
+    "lab": "15.x.x"
   },
   "keywords": [
     "hapi",

--- a/test/index.js
+++ b/test/index.js
@@ -11,294 +11,255 @@ const expect = Code.expect;
 const describe = lab.describe;
 const it = lab.it;
 
-function prepareServer (callback) {
+async function prepareServer () {
   const server = new Hapi.Server();
+  await server.register(Plugin);
 
-  server.connection();
-  server.register([Plugin], (err) => {
-    if (err) {
-      return callback(err);
-    }
+  server.auth.scheme('test', function (server, options) {
+    return {
+      authenticate (request, h) {
+        const header = request.headers[options.header];
 
-    server.auth.scheme('test', function (server, options) {
-      return {
-        authenticate (request, reply) {
-          const header = request.headers[options.header];
+        if (header === options.value) {
+          const credentials = options.credentials !== undefined ?
+            options.credentials : {
+              [options.header]: options.value,
+              scope: options.scope
+            };
 
-          if (header === options.value) {
-            const credentials = options.credentials !== undefined ?
-                                options.credentials : {
-                                  [options.header]: options.value,
-                                  scope: options.scope
-                                };
-
-            return reply.continue({ credentials });
-          }
-
-          reply(Boom.unauthorized());
+          return h.authenticated({ credentials });
         }
-      };
-    });
+        throw Boom.unauthorized();
+      }
+    };
+  });
 
-    server.auth.scheme('failScheme', function (server, options) {
-      return {
-        authenticate (request, reply) {
-          server.app.failed = true;
-          reply(Boom.internal());
-        }
-      };
-    });
+  server.auth.scheme('failScheme', function (server, options) {
+    return {
+      authenticate (request, h) {
+        server.app.failed = true;
+        throw Boom.internal();
+      }
+    };
+  });
 
-    server.auth.strategy('fooAuth', 'test', { header: 'foo', value: 42 });
-    server.auth.strategy('barAuth', 'test', { header: 'bar', value: 53 });
-    server.auth.strategy('bazAuth', 'test', { header: 'baz', value: 64, scope: ['baz', 'foo'] });
-    server.auth.strategy('badCreds', 'test', { header: 'bad', value: 99, credentials: null });
-    server.auth.strategy('stringCreds', 'test', { header: 'bad', value: 99, credentials: 'creds' });
-    server.auth.strategy('fail', 'failScheme');
+  server.auth.strategy('fooAuth', 'test', { header: 'foo', value: 42 });
+  server.auth.strategy('barAuth', 'test', { header: 'bar', value: 53 });
+  server.auth.strategy('bazAuth', 'test', { header: 'baz', value: 64, scope: ['baz', 'foo'] });
+  server.auth.strategy('stringCreds', 'test', { header: 'bad', value: 99, credentials: 'creds' });
+  server.auth.strategy('fail', 'failScheme');
 
-    server.auth.strategy('fooOnly', 'nuisance', {
-      strategies: ['fooAuth']
-    });
-    server.auth.strategy('fooWithDefaults', 'nuisance', {
-      strategies: [
-        {
-          name: 'fooAuth',
-          failureCredentials (request) {
-            return { path: request.path };
-          }
-        }
-      ]
-    });
-    server.auth.strategy('fooBar', 'nuisance', {
-      strategies: ['fooAuth', 'barAuth']
-    });
-    server.auth.strategy('fooBarBaz', 'nuisance', {
-      strategies: ['fooAuth', { name: 'barAuth' }, 'bazAuth']
-    });
-    server.auth.strategy('fooStringCredsBadCreds', 'nuisance', {
-      strategies: ['fooAuth', 'stringCreds', 'badCreds']
-    });
-    server.auth.strategy('fooFail', 'nuisance', {
-      strategies: ['fooAuth', 'fail']
-    });
-    server.auth.strategy('fooBarBazString', 'nuisance', {
-      strategies: ['fooAuth', 'barAuth', 'bazAuth', 'stringCreds']
-    });
-
-    function handler (request, reply) {
-      reply(request.auth);
-    }
-
-    server.route([
+  server.auth.strategy('fooOnly', 'nuisance', {
+    strategies: ['fooAuth']
+  });
+  server.auth.strategy('fooWithDefaults', 'nuisance', {
+    strategies: [
       {
-        method: 'GET',
-        path: '/foo',
-        config: {
-          auth: 'fooOnly',
-          handler
-        }
-      },
-      {
-        method: 'GET',
-        path: '/foo/with/defaults',
-        config: {
-          auth: 'fooWithDefaults',
-          handler
-        }
-      },
-      {
-        method: 'GET',
-        path: '/foo/bar',
-        config: {
-          auth: 'fooBar',
-          handler
-        }
-      },
-      {
-        method: 'GET',
-        path: '/foo/bar/baz',
-        config: {
-          auth: 'fooBarBaz',
-          handler
-        }
-      },
-      {
-        method: 'GET',
-        path: '/foo/stringCreds/badCreds',
-        config: {
-          auth: 'fooStringCredsBadCreds',
-          handler
-        }
-      },
-      {
-        method: 'GET',
-        path: '/foo/fail',
-        config: {
-          auth: 'fooFail',
-          handler
+        name: 'fooAuth',
+        failureCredentials (request) {
+          return { path: request.path };
         }
       }
-    ]);
-
-    callback(null, server);
+    ]
   });
+  server.auth.strategy('fooBar', 'nuisance', {
+    strategies: ['fooAuth', 'barAuth']
+  });
+  server.auth.strategy('fooBarBaz', 'nuisance', {
+    strategies: ['fooAuth', { name: 'barAuth' }, 'bazAuth']
+  });
+  server.auth.strategy('fooStringCreds', 'nuisance', {
+    strategies: ['fooAuth', 'stringCreds']
+  });
+  server.auth.strategy('fooFail', 'nuisance', {
+    strategies: ['fooAuth', 'fail']
+  });
+  server.auth.strategy('fooBarBazString', 'nuisance', {
+    strategies: ['fooAuth', 'barAuth', 'bazAuth', 'stringCreds']
+  });
+
+  function handler (request, h) {
+    return request.auth;
+  }
+
+  server.route([
+    {
+      method: 'GET',
+      path: '/foo',
+      config: {
+        auth: 'fooOnly',
+        handler
+      }
+    },
+    {
+      method: 'GET',
+      path: '/foo/with/defaults',
+      config: {
+        auth: 'fooWithDefaults',
+        handler
+      }
+    },
+    {
+      method: 'GET',
+      path: '/foo/bar',
+      config: {
+        auth: 'fooBar',
+        handler
+      }
+    },
+    {
+      method: 'GET',
+      path: '/foo/bar/baz',
+      config: {
+        auth: 'fooBarBaz',
+        handler
+      }
+    },
+    {
+      method: 'GET',
+      path: '/foo/stringCreds',
+      config: {
+        auth: 'fooStringCreds',
+        handler
+      }
+    },
+    {
+      method: 'GET',
+      path: '/foo/fail',
+      config: {
+        auth: 'fooFail',
+        handler
+      }
+    }
+  ]);
+
+  return server;
 }
 
 describe('Nuisance', () => {
-  it('authenticates multiple strategies at once', (done) => {
-    prepareServer((err, server) => {
-      expect(err).to.not.exist();
-
-      server.inject({
-        method: 'GET',
-        url: '/foo/bar/baz',
-        headers: {
-          foo: 42,
-          bar: 53,
-          baz: 64
-        }
-      }, (res) => {
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.include({
-          isAuthenticated: true,
-          credentials: {
-            fooAuth: { foo: 42 },
-            barAuth: { bar: 53 },
-            bazAuth: { baz: 64 },
-            scope: ['baz', 'foo']
-          },
-          strategy: 'fooBarBaz',
-          mode: 'required',
-          error: null
-        });
-        done();
-      });
+  it('authenticates multiple strategies at once', async () => {
+    const server = await prepareServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/foo/bar/baz',
+      headers: {
+        foo: 42,
+        bar: 53,
+        baz: 64
+      }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result).to.include({
+      isAuthenticated: true,
+      credentials: {
+        fooAuth: { foo: 42 },
+        barAuth: { bar: 53 },
+        bazAuth: { baz: 64 },
+        scope: ['baz', 'foo']
+      },
+      strategy: 'fooBarBaz',
+      mode: 'required',
+      error: null
     });
   });
 
-  it('authenticates fails if any strategies fail', (done) => {
-    prepareServer((err, server) => {
-      expect(err).to.not.exist();
-
-      server.inject({
-        method: 'GET',
-        url: '/foo/bar/baz',
-        headers: {
-          foo: 42,
-          bar: 53,
-          baz: 63 // fails
-        }
-      }, (res) => {
-        expect(res.statusCode).to.equal(401);
-        expect(res.result).to.equal({
-          statusCode: 401,
-          error: 'Unauthorized'
-        });
-        done();
-      });
+  it('authenticates fails if any strategies fail', async () => {
+    const server = await prepareServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/foo/bar/baz',
+      headers: {
+        foo: 42,
+        bar: 53,
+        baz: 63 // fails
+      }
+    });
+    expect(res.statusCode).to.equal(401);
+    expect(res.result).to.equal({
+      statusCode: 401,
+      error: 'Unauthorized'
     });
   });
 
-  it('does not expose scope if none of the strategies set it', (done) => {
-    prepareServer((err, server) => {
-      expect(err).to.not.exist();
+  it('does not expose scope if none of the strategies set it', async () => {
+    const server = await prepareServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/foo/bar',
+      headers: {
+        foo: 42,
+        bar: 53
+      }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result).to.include({
+      isAuthenticated: true,
+      credentials: {
+        fooAuth: { foo: 42 },
+        barAuth: { bar: 53 }
+      },
+      strategy: 'fooBar',
+      mode: 'required',
+      error: null
+    });
 
-      server.inject({
-        method: 'GET',
-        url: '/foo/bar',
-        headers: {
-          foo: 42,
-          bar: 53
-        }
-      }, (res) => {
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.include({
-          isAuthenticated: true,
-          credentials: {
-            fooAuth: { foo: 42 },
-            barAuth: { bar: 53 }
-          },
-          strategy: 'fooBar',
-          mode: 'required',
-          error: null
-        });
+    expect(res.result.credentials.scope).to.be.undefined();
+  });
 
-        expect(res.result.credentials.scope).to.be.undefined();
-        done();
-      });
+  it('handles credentials that are not objects', async () => {
+    const server = await prepareServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/foo/stringCreds',
+      headers: {
+        foo: 42,
+        bad: 99
+      }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result).to.include({
+      isAuthenticated: true,
+      credentials: {
+        fooAuth: { foo: 42 },
+        stringCreds: 'creds'
+      },
+      strategy: 'fooStringCreds',
+      mode: 'required',
+      error: null
     });
   });
 
-  it('handles credentials that are not objects', (done) => {
-    prepareServer((err, server) => {
-      expect(err).to.not.exist();
-
-      server.inject({
-        method: 'GET',
-        url: '/foo/stringCreds/badCreds',
-        headers: {
-          foo: 42,
-          bad: 99
-        }
-      }, (res) => {
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.include({
-          isAuthenticated: true,
-          credentials: {
-            fooAuth: { foo: 42 },
-            stringCreds: 'creds',
-            badCreds: null
-          },
-          strategy: 'fooStringCredsBadCreds',
-          mode: 'required',
-          error: null
-        });
-        done();
-      });
+  it('allows failure credentials to be set', async () => {
+    const server = await prepareServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/foo/with/defaults',
+      headers: { foo: 100 }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result).to.include({
+      isAuthenticated: true,
+      credentials: { fooAuth: { path: '/foo/with/defaults' } },
+      strategy: 'fooWithDefaults',
+      mode: 'required',
+      error: null
     });
   });
 
-  it('allows failure credentials to be set', (done) => {
-    prepareServer((err, server) => {
-      expect(err).to.not.exist();
-
-      server.inject({
-        method: 'GET',
-        url: '/foo/with/defaults',
-        headers: { foo: 100 }
-      }, (res) => {
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.include({
-          isAuthenticated: true,
-          credentials: { fooAuth: { path: '/foo/with/defaults' } },
-          strategy: 'fooWithDefaults',
-          mode: 'required',
-          error: null
-        });
-        done();
-      });
+  it('stops after first failing strategy', async () => {
+    const server = await prepareServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/foo/fail',
+      headers: {
+        foo: 1 // fails
+      }
     });
-  });
-
-  it('stops after first failing strategy', (done) => {
-    prepareServer((err, server) => {
-      expect(err).to.not.exist();
-
-      server.inject({
-        method: 'GET',
-        url: '/foo/fail',
-        headers: {
-          foo: 1 // fails
-        }
-      }, (res) => {
-        expect(res.statusCode).to.equal(401);
-        expect(res.result).to.equal({
-          statusCode: 401,
-          error: 'Unauthorized'
-        });
-        expect(server.app.failed).to.not.exist();
-        done();
-      });
+    expect(res.statusCode).to.equal(401);
+    expect(res.result).to.equal({
+      statusCode: 401,
+      error: 'Unauthorized'
     });
+    expect(server.app.failed).to.not.exist();
   });
 });


### PR DESCRIPTION
Great library! I updated it to hapi v17, along with some dependencies that failed at lesser versions. Along the way, it migrated from callbacks to `await`. Unfortunately that means the diff is hard to read because of indentation changes...aside from hapi API changes, it's mostly indentation.

The only thing that changed in terms of behavior is handling null credentials. I removed the `badCreds` strategy because `h.authenticated()` expects `credentials` to be truthy, and throws a 500 error otherwise.